### PR TITLE
fix: Bazzite Portal real estate fix

### DIFF
--- a/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
+++ b/system_files/desktop/shared/usr/share/ublue-os/firstboot/yafti.yml
@@ -186,7 +186,7 @@ screens:
           - Spotify: com.spotify.Client
           - Strawberry Music Player: org.strawberrymusicplayer.strawberry
           - Tidal-hifi: com.mastermindzh.tidal-hifi
-        Office/Productivity:
+        Office and Productivity:
           description: Bow to Capitalism
           default: false
           packages:
@@ -206,7 +206,7 @@ screens:
           - Tenacity: org.tenacityaudio.Tenacity
           - Thunderbird Email: org.mozilla.Thunderbird
           - Xournal++: com.github.xournalpp.xournalpp
-        Utilities:
+        Utilities and System Tools:
           description: Helpful tools
           default: false
           packages:
@@ -219,16 +219,12 @@ screens:
           - KeePassXC: org.keepassxc.KeePassXC
           - Metadata Cleaner: fr.romainvigier.MetadataCleaner
           - OpenRGB: org.openrgb.OpenRGB
+          - Pika Backup: org.gnome.World.PikaBackup
+          - PinApp: io.github.fabrialberio.pinapp
           - qBittorrent: org.qbittorrent.qBittorrent
+          - Resources: net.nokyan.Resources
           - Syncthing: com.github.zocker_160.SyncThingy
           - VLC: org.videolan.VLC
-        System Management:
-          description: Manage application data
-          default: false
-          packages:
-          - PinApp: io.github.fabrialberio.pinapp
-          - SaveDesktop: io.github.vikdevelop.SaveDesktop
-          - Warehouse: io.github.flattool.Warehouse
   theme:
     source: yafti.screen.title
     values:


### PR DESCRIPTION
Renamed Utilities to Utilities and System Tools.
Moved PinApp back to Utilities.
Added Resources (https://flathub.org/apps/net.nokyan.Resources) Added Pika Backup (https://flathub.org/apps/org.gnome.World.PikaBackup)

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
